### PR TITLE
Add basic frontend test

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/main.tsx --bundle --outfile=dist/assets/app.js --loader:.tsx=tsx --loader:.ts=ts && cp index.html dist/index.html"
+    "build": "esbuild src/main.tsx --bundle --outfile=dist/assets/app.js --loader:.tsx=tsx --loader:.ts=ts && cp index.html dist/index.html",
+    "test": "node --test"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/frontend/tests/smoke.test.js
+++ b/frontend/tests/smoke.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('basic arithmetic works', () => {
+  assert.strictEqual(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- add simple smoke test using Node's built-in test runner
- wire up `npm test` script to run tests

## Testing
- `pytest`
- `npm test`
- `docker compose config` *(fails: command not found)*
- `python -m py_compile gateway/main.py analysis/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689fbd78931083309979dfe9be7da5ed